### PR TITLE
Fix security

### DIFF
--- a/rss-synd.tcl
+++ b/rss-synd.tcl
@@ -1,3 +1,4 @@
+# -*- tab-width: 4; indent-tabs-mode: t; -*-
 # rss-synd.tcl -- 0.5.1
 #
 #   Highly configurable asynchronous RSS & Atom feed reader for Eggdrops 


### PR DESCRIPTION
There seems to be a rather serious problem with the "tcl-eval" mode of feed parsing in that strings are inserted into the program and then executed. Strings from the feeds.

I noticed it because I got errors that were caused by a feed using [, ], " and some other characters in the text I wanted to display.

Now I've not coded Tcl for ~9 years so I'm not sure this is the optimal solution but it seems to work. Instead of inserting "This string comes from the feed" into $output, it inserts $cookie_val(1) and sets cookie_val(1) to that string.

It seems to work.

(By the way, if you ever work more on this, I'd suggest using the word "tmp" less and using more informative variable names, and not reusing variables for more than one purpose. Such changes would make the code easier to read - on the other hand, none of us like to code Tcl)
